### PR TITLE
Forum page control usability updates

### DIFF
--- a/app/assets/javascripts/templates/forums/controls_partial.hbs
+++ b/app/assets/javascripts/templates/forums/controls_partial.hbs
@@ -1,0 +1,7 @@
+<button class="btn" {{action 'create_forum'}}>Create Forum</button>
+{{#if has_prev_page}}
+    <button class="btn" {{action 'prev_page'}}>More Recent</button>
+{{/if}}
+{{#if has_next_page}}
+    <button class="btn" {{action 'next_page'}}>Older</button>
+{{/if}}

--- a/app/assets/javascripts/templates/forums/controls_partial.hbs
+++ b/app/assets/javascripts/templates/forums/controls_partial.hbs
@@ -1,4 +1,4 @@
-<button class="btn" {{action 'create_forum'}}>Create Forum</button>
+<button {{bind-attr class="logged_in::hidden btn"}} {{action 'create_forum'}}>Create Forum</button>
 {{#if has_prev_page}}
     <button class="btn" {{action 'prev_page'}}>More Recent</button>
 {{/if}}

--- a/app/assets/javascripts/templates/forums/detail.hbs
+++ b/app/assets/javascripts/templates/forums/detail.hbs
@@ -1,7 +1,12 @@
 <div class="main-page-header header-with-controls">
-  {{#if has_prev_page}}
-    <button class="controls btn" {{action 'prev_page'}}>Older</button>
-  {{/if}}
+  <span class="controls">
+    {{#if has_prev_page}}
+      <button class="btn" {{action 'prev_page'}}>Older</button>
+    {{/if}}
+    {{#if has_next_page}}
+      <button class="btn" {{action 'next_page'}}>Newer</button>
+    {{/if}}
+  </span>
   <div class="title">{{#link-to 'forums' }}Forums{{/link-to}} > {{forum.subject}}
     <button class="btn btn-link" {{action 'reload'}}><span class="glyphicon glyphicon-repeat" title="Refresh"></span></button>
   </div>
@@ -30,8 +35,13 @@
   </div>
 </div>
 
-<div {{bind-attr class="has_next_page::hidden has_new_posts::scroll_to :footer-controls"}}>
+<div {{bind-attr class="has_new_posts::scroll_to :footer-controls"}}>
   <div class="card-section">
-    <button class="controls btn" {{action 'next_page'}}>More</button>
+    {{#if has_prev_page}}
+      <button class="controls btn" {{action 'prev_page'}}>Older</button>
+    {{/if}}
+    {{#if has_next_page}}
+      <button class="controls btn" {{action 'next_page'}}>Newer</button>
+    {{/if}}
   </div>
 </div>

--- a/app/assets/javascripts/templates/forums/page.hbs
+++ b/app/assets/javascripts/templates/forums/page.hbs
@@ -1,9 +1,6 @@
 <div class="main-page-header header-with-controls">
   <span class="controls">
-    <button class="btn" {{action 'create_forum'}}>Create Forum</button>
-    {{#if has_prev_page}}
-      <button class="btn" {{action 'prev_page'}}>More Recent</button>
-    {{/if}}
+    {{render "forums.controls_partial" this}}
   </span>
 
   <div class="title">Forums
@@ -18,8 +15,8 @@
   {{/each}}
 </div>
 
-<div {{bind-attr class="has_next_page::hidden :footer-controls"}}>
+<div {{bind-attr class=":footer-controls"}}>
   <div class="card-section">
-    <button class="controls btn" {{action 'next_page'}}>Older</button>
+    {{render "forums.controls_partial" this}}
   </div>
 </div>

--- a/app/controllers/api/v2/forums_controller.rb
+++ b/app/controllers/api/v2/forums_controller.rb
@@ -6,7 +6,7 @@ class API::V2::ForumsController < ApplicationController
   before_filter :fetch_forum, :except => [:index, :create, :show, :rc_forums, :rc_forum]
 
   def index
-    page_size = (params[:limit] || 20).to_i
+    page_size = (params[:limit] || POST_COUNT).to_i
     page = (params[:page] || 0).to_i
 
     query = Forum.all.desc(:last_post_time).offset(page * page_size).limit(page_size)

--- a/app/decorators/forum_decorator.rb
+++ b/app/decorators/forum_decorator.rb
@@ -15,7 +15,7 @@ class ForumDecorator < Draper::Decorator
     unless user.nil?
       count = post_count_since(user.last_forum_view(id.to_s))
       ret[:new_posts] = count if count > 0
-      ret[:last_post_page] = count / 20 if count > 0
+      ret[:last_post_page] = (post_count - count) / 20
     end
     ret
   end


### PR DESCRIPTION
- Display create post button and forward/back page buttons at the top and bottom of each forum page
- Display forward/back page buttons at the top and bottom of each posts page
- When a logged in user clicks in to a forum post, take them to their most recently read post (bugfix)
- Hide Create Forum button when user is not logged in