### PR TITLE
Sort by ID, not Timestamp - more consistent sorting. Use Time instead of DateTime everywhere.

### DIFF
--- a/app/controllers/api/v2/alerts_controller.rb
+++ b/app/controllers/api/v2/alerts_controller.rb
@@ -18,12 +18,12 @@ class API::V2::AlertsController < ApplicationController
         current_user.save!
       end
     else
-      last_checked_time = session[:last_viewed_alerts] || Time.at(0).to_datetime
+      last_checked_time = session[:last_viewed_alerts] || Time.at(0)
       tweet_mentions = []
       forum_mentions = []
       unread_seamail = []
       upcoming_events = []
-      session[:last_viewed_alerts] = DateTime.now unless params[:no_reset]
+      session[:last_viewed_alerts] = Time.now unless params[:no_reset]
     end
     render json: { tweet_mentions: tweet_mentions, forum_mentions: forum_mentions,
                 announcements: announcements, unread_seamail: unread_seamail, upcoming_events: upcoming_events, last_checked_time: last_checked_time.to_ms }
@@ -33,7 +33,7 @@ class API::V2::AlertsController < ApplicationController
     if logged_in?
       render json: { status: 'ok', user: current_user.decorate.alerts_meta }
     else
-      last_checked_time = session[:last_viewed_alerts] || Time.at(0).to_datetime
+      last_checked_time = session[:last_viewed_alerts] || Time.at(0)
       render json: { status: 'ok', user:{unnoticed_announcements:Announcement.new_announcements(last_checked_time).count} }
     end
 

--- a/app/controllers/api/v2/event_controller.rb
+++ b/app/controllers/api/v2/event_controller.rb
@@ -22,7 +22,7 @@ class API::V2::EventController < ApplicationController
       if params[:start_time] =~ /^\d+$/
         @event.start_time = Time.at(params[:start_time].to_i / 1000.0)
       else
-        @event.start_time = DateTime.parse params[:start_time]
+        @event.start_time = Time.parse(params[:start_time])
       end
     end
     @event.end_time = Time.parse(params[:end_time]) unless params[:end_time].blank?

--- a/app/controllers/api/v2/seamail_controller.rb
+++ b/app/controllers/api/v2/seamail_controller.rb
@@ -28,7 +28,7 @@ class API::V2::SeamailController < ApplicationController
       if params[:after] =~ /^\d+$/
         val = Time.at(params[:after].to_i / 1000.0)
       else
-        val = DateTime.parse params[:after]
+        val = Time.parse(params[:after])
       end
       if val
         extra_query[:after] = val

--- a/app/controllers/api/v2/stream_controller.rb
+++ b/app/controllers/api/v2/stream_controller.rb
@@ -41,7 +41,7 @@ class API::V2::StreamController < ApplicationController
     end
 
     has_next_page = posts.count > params[:limit]
-    posts = posts.limit(0 - params[:limit]).order_by(timestamp: sort) # Limit needs to be negative, otherwise mongo will return additional posts
+    posts = posts.limit(0 - params[:limit]).order_by(id: sort) # Limit needs to be negative, otherwise mongo will return additional posts
 
     posts = posts.map { |x| x } # Execute the query, so that our results are the expected size
 
@@ -73,7 +73,7 @@ class API::V2::StreamController < ApplicationController
     show_options = request_options
     show_options[:remove] = [:parent_chain]
     has_next_page = StreamPost.where(parent_chain: params[:id]).count > ((start_loc + 1) * limit)
-    children = StreamPost.where(parent_chain: params[:id]).limit(limit).skip(start_loc*limit).order_by(timestamp: :asc).map { |x| x.decorate.to_hash(current_username, show_options) }
+    children = StreamPost.where(parent_chain: params[:id]).limit(limit).skip(start_loc*limit).order_by(id: :asc).map { |x| x.decorate.to_hash(current_username, show_options) }
     post_result = @post.decorate.to_hash(current_username, request_options)
     if children and children.length > 0
       post_result[:children] = children
@@ -209,7 +209,7 @@ class API::V2::StreamController < ApplicationController
   end
 
   def newest_posts(query)
-    start = DateTime.now.to_ms
+    start = Time.now.to_ms
     params[:start] = start
     older_posts(query)
   end

--- a/app/controllers/api/v2/user_controller.rb
+++ b/app/controllers/api/v2/user_controller.rb
@@ -86,7 +86,7 @@ class API::V2::UserController < ApplicationController
     end
     hash = user.decorate.public_hash.merge(
       {
-          recent_tweets: StreamPost.where(author: user.username).desc(:timestamp).limit(10).map { |x| x.decorate.to_hash(current_username, request_options) }
+          recent_tweets: StreamPost.where(author: user.username).desc(:id).limit(10).map { |x| x.decorate.to_hash(current_username, request_options) }
       })
     hash[:starred] = current_user.starred_users.include?(user.username) if logged_in? 
     hash[:comment] = current_user.personal_comments[user.username] if logged_in?

--- a/app/models/concerns/postable.rb
+++ b/app/models/concerns/postable.rb
@@ -104,13 +104,13 @@ module Postable
         if params[:after] =~ /^\d+$/
           val = Time.at(params[:after].to_i / 1000.0)
         else
-          val = DateTime.parse params[:after]
+          val = Time.parse params[:after]
         end
         if val
           query = query.where(:timestamp.gt => val)
         end
       end
-      query.order_by(timestamp: :desc).skip(start_loc*limit).limit(limit)
+      query.order_by(id: :desc).skip(start_loc*limit).limit(limit)
     end
 
     def view_hashtags(params = {})
@@ -123,13 +123,13 @@ module Postable
         if params[:after] =~ /^\d+$/
           val = Time.at(params[:after].to_i / 1000.0)
         else
-          val = DateTime.parse params[:after]
+          val = Time.parse params[:after]
         end
         if val
           query = query.where(:timestamp.gt => params[:after])
         end
       end
-      query.order_by(timestamp: :desc).skip(start_loc*limit).limit(limit)
+      query.order_by(id: :desc).skip(start_loc*limit).limit(limit)
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,7 +24,7 @@ class Event
   def self.search(params = {})
     search_text = params[:query].strip.downcase.gsub(/[^\w&\s@-]/, '')
     criteria = Event.or({title: /^#{search_text}.*/}, {'$text' => {'$search' => "\"#{search_text}\""}})
-    limit_criteria(criteria, params).order_by(timestamp: :desc)
+    limit_criteria(criteria, params).order_by(id: :desc)
   end
 
   def self.create_new_event(author, title, start_time, options={})

--- a/app/models/forum.rb
+++ b/app/models/forum.rb
@@ -73,13 +73,13 @@ class Forum
       if params[:after] =~ /^\d+$/
         val = Time.at(params[:after].to_i / 1000.0)
       else
-        val = DateTime.parse params[:after]
+        val = Time.parse params[:after]
       end
       if val
         query = query.gt(:'fp.ts' => val)
       end
     end
-    query.order_by(timestamp: :desc).skip(start_loc*limit).limit(limit)
+    query.order_by(id: :desc).skip(start_loc*limit).limit(limit)
   end
 
   def self.search(params = {})

--- a/app/models/stream_post.rb
+++ b/app/models/stream_post.rb
@@ -83,7 +83,7 @@ class StreamPost
   def self.search(params = {})
     search_text = params[:query].strip.downcase.gsub(/[^\w&\s@-]/, '')
     criteria = StreamPost.or({ author: /^#{search_text}.*/ }, { '$text' => { '$search' => "\"#{search_text}\"" } })
-    limit_criteria(criteria, params).order_by(timestamp: :desc)
+    limit_criteria(criteria, params).order_by(id: :desc)
   end
 
   def validate_photo

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,8 +144,8 @@ class User
   end
 
   def upcoming_events(alerts=false)
-    events = Event.where(:start_time.gte => (DateTime.now - 1.hours)).where(:start_time.lte => (DateTime.now + 3.hours)).limit(20).order_by(:start_time.desc)
-    events = events.map {|x| x if !x.end_time or x.end_time > DateTime.now }.compact
+    events = Event.where(:start_time.gte => (Time.now - 1.hours)).where(:start_time.lte => (Time.now + 3.hours)).limit(20).order_by(:start_time.desc)
+    events = events.map {|x| x if !x.end_time or x.end_time > Time.now }.compact
     events = events.map { |x| x if x.favorites.include? self.username }.compact
     if alerts
       events = events.map { |e| e unless self.acknowledged_event_alerts.include? e.id }.compact
@@ -291,7 +291,7 @@ class User
 
   def reset_last_viewed_alerts
     reset_mentions
-    self.last_viewed_alerts = DateTime.now
+    self.last_viewed_alerts = Time.now
   end
 
   def unnoticed_announcements

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,4 +1,4 @@
-@BASE_DATE = DateTime.now - 1.day
+@BASE_DATE = Time.now - 1.day
 puts "Using a base date of #{@BASE_DATE}"
 
 def create_registration_code(code)
@@ -67,7 +67,7 @@ end
 
 def at_time(hr, min, params = {})
   dt = @BASE_DATE
-  dt = dt - params[:offset] if params.has_key? :offset
+  dt = dt + params[:offset] if params.has_key? :offset
   params.delete :offset
   params[:hour] = hr
   params[:min] = min


### PR DESCRIPTION
Resolves #123 