### PR TITLE
Image upload changes - use image_voodoo instead of rmagick4j

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,8 @@ gem 'draper', '~> 1.3'
 gem 'andand'
 gem 'browser'
 
-gem 'rmagick4j'
-gem 'exifr'
+gem 'rmagick4j', '= 0.3.8', :require => 'RMagick'
+gem 'image_voodoo', :require => 'image_voodoo'
 gem 'puma'
 
 gem 'siphash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,6 @@ GEM
     ember-source (1.13.13)
     erubis (2.7.0)
     execjs (2.7.0)
-    exifr (1.2.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     handlebars-source (4.1.0)
@@ -100,6 +99,7 @@ GEM
     icalendar (2.5.2)
       ice_cube (~> 0.16)
     ice_cube (0.16.3)
+    image_voodoo (0.8.9)
     jbuilder (2.2.7)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -226,9 +226,9 @@ DEPENDENCIES
   ember-data-source (~> 1.13.0)
   ember-rails (~> 0.19.0)
   ember-source (~> 1.13.0)
-  exifr
   handlebars-source
   icalendar (>= 2.3.0)
+  image_voodoo
   jbuilder
   jquery-rails (~> 4.0.0)
   minitest (~> 5.4.3)
@@ -240,7 +240,7 @@ DEPENDENCIES
   puma
   rack-cors
   rails (= 4.2.11)
-  rmagick4j
+  rmagick4j (= 0.3.8)
   sass-rails (~> 5.0)
   sdoc
   siphash

--- a/app/controllers/api/v2/photo_controller.rb
+++ b/app/controllers/api/v2/photo_controller.rb
@@ -6,6 +6,7 @@ class API::V2::PhotoController < ApplicationController
   PAGE_LENGTH = 20
   before_action :login_required, :only => [:create, :destroy, :update]
   before_action :not_muted, :only => [:create, :update]
+  before_action :admin_required, :only => [:index]
   before_action :fetch_photo, :except => [:index, :create]
 
   def fetch_photo

--- a/config/initializers/utilities.rb
+++ b/config/initializers/utilities.rb
@@ -42,3 +42,11 @@ class Time
     end
   end
 end
+
+# Fixes a stupid error in the ImageVoodoo library. Don't have time to wait for a new version
+# https://github.com/jruby/image_voodoo/issues/21
+class ImageVoodoo
+  def calculate_thumbnail_dimentions
+    calculate_thumbnail_dimensions
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,7 @@ Twitarr::Application.routes.draw do
       get 'reactions', to: 'text#reactions'
       get 'announcements', to: 'text#announcements'
 
-      resources :photo, only: [:create, :destroy, :update, :show], :defaults => { :format => 'json' } # :index endpoint exists, but is disabled
+      resources :photo, only: [:index, :create, :destroy, :update, :show], :defaults => { :format => 'json' }
       get 'photo/small_thumb/:id', to: 'photo#small_thumb'
       get 'photo/medium_thumb/:id', to: 'photo#medium_thumb'
       get 'photo/full/:id', to: 'photo#full'

--- a/rest_documentation.md
+++ b/rest_documentation.md
@@ -919,9 +919,14 @@ All reactions that have been applied to the post.
 }
 ```
 
-### GET /api/v2/photo - DISABLED
+### GET /api/v2/photo
 
-Gets a list of images that have been uploaded to the server. This endpoint is currently disabled, since adequate image management tools do not currently exist.
+Gets a list of images that have been uploaded to the server. This endpoint is currently admin-only, since adequate management tools do not currently exist.
+
+#### Requires
+
+* logged in as admin.
+    * Accepts: key query parameter
 
 #### Query parameters
 
@@ -944,7 +949,7 @@ A listing of photo metadata.
 ```
 
 #### Error Responses
-
+* status_code_only - HTTP 401 if user is not logged in as an admin
 * status_code_with_error_list - HTTP 400 with a list of any problems
   ```
   {


### PR DESCRIPTION
Use image_voodoo for post and uploaded profile images
Correct the rotation of uploaded images based on metadata
Allow admins to hit the image index