### PR TITLE
Alerts Updates

### DIFF
--- a/app/assets/javascripts/templates/alerts.hbs
+++ b/app/assets/javascripts/templates/alerts.hbs
@@ -67,6 +67,10 @@
   <div class="card_title">Tweet Mentions</div>
   {{#each tweet in model.tweet_mentions}}
     {{render "stream.post_partial" tweet}}
+  {{else}}
+    <div class="card-section">
+      No new tweet mentions.
+    </div>
   {{/each}}
 </div>
 
@@ -74,5 +78,9 @@
   <div class="card_title">Forum Mentions</div>
   {{#each forum in model.forum_mentions}}
     {{render "forums.meta_partial" forum}}
+  {{else}}
+    <div class="card-section">
+      No new forum mentions.
+    </div>
   {{/each}}
 </div>

--- a/app/controllers/api/v2/user_controller.rb
+++ b/app/controllers/api/v2/user_controller.rb
@@ -1,7 +1,7 @@
 class API::V2::UserController < ApplicationController
   skip_before_action :verify_authenticity_token
 
-  before_action :login_required, :only => [:new_seamail, :whoami, :star, :starred, :personal_comment, :update_profile, :change_password, :reset_photo, :update_photo, :reset_mentions, :mentions, :upload_schedule]
+  before_action :login_required, :only => [:new_seamail, :whoami, :star, :starred, :personal_comment, :update_profile, :change_password, :reset_photo, :update_photo, :mentions, :upload_schedule]
   before_action :not_muted, :only => [:update_photo]
   before_action :fetch_user, :only => [:show, :star, :personal_comment, :get_photo]
 
@@ -202,11 +202,6 @@ class API::V2::UserController < ApplicationController
     else
       render json: results
     end
-  end
-
-  def reset_mentions
-    current_user.reset_mentions
-    render json: { status: 'ok', mentions: current_user.unnoticed_mentions }
   end
 
   def mentions

--- a/app/models/concerns/postable.rb
+++ b/app/models/concerns/postable.rb
@@ -48,22 +48,7 @@ module Postable
     end
 
     def post_create_operations
-      increment_mentions_counts
       record_hashtags
-    end
-
-    def increment_mentions_counts
-      unknown_users = []
-      self.mentions.each { |mentioned_user|
-        begin
-          User.inc_mentions mentioned_user
-        rescue Mongoid::Errors::DocumentNotFound => e
-          unknown_users.push mentioned_user
-        rescue => e
-          logger.info "Unable to increment mention for user: #{mentioned_user}: #{e.class.name}: #{e.message}"
-        end
-      }
-      logger.info "Unable to find mentioned user(s) #{unknown_users.join ','} to increment mention count" unless unknown_users.empty?
     end
 
     def record_hashtags

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,6 @@ class User
   field :em, as: :email, type: String
   field :dn, as: :display_name, type: String
   field :ll, as: :last_login, type: Time, default: Time.at(0)
-  field :um, as: :unnoticed_mentions, type: Integer, default: 0
   field :al, as: :last_viewed_alerts, type: Time, default: Time.at(0)
   field :ph, as: :photo_hash, type: String
   field :pu, as: :last_photo_updated, type: Time, default: Time.now
@@ -326,16 +325,9 @@ class User
     path
   end
 
-  def inc_mentions
-    inc(unnoticed_mentions: 1)
-  end
-
-  def self.inc_mentions(username)
-    User.find_by(username: username).inc(unnoticed_mentions: 1)
-  end
-
-  def reset_mentions
-    set(unnoticed_mentions: 0)
+  def unnoticed_mentions
+    StreamPost.view_mentions(query: self.username, after: self.last_viewed_alerts, mentions_only: true).count +
+      Forum.view_mentions(query: self.username, after: self.last_viewed_alerts, mentions_only: true).count
   end
 
   def update_forum_view(forum_id)
@@ -343,9 +335,8 @@ class User
     save
   end
 
-  def reset_last_viewed_alerts
-    reset_mentions
-    self.last_viewed_alerts = Time.now
+  def reset_last_viewed_alerts(time = Time.now)
+    self.last_viewed_alerts = time
   end
 
   def unnoticed_announcements

--- a/config/initializers/utilities.rb
+++ b/config/initializers/utilities.rb
@@ -35,9 +35,11 @@ class Time
   end
 
   def self.from_param(input)
-    if input.is_a?(Integer) || input =~ /^\d+$/
-      Time.at(input.to_i / 1000)
-    elsif input
+    if input.respond_to?(:strftime)
+      input
+    elsif input.is_a?(Integer) || input =~ /^\d+$/
+      Time.at(input.to_i / 1000.0)
+    else
       Time.parse(input)
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,6 @@ Twitarr::Application.routes.draw do
 
       post 'user/new', to: 'user#new'
       get 'user/new_seamail', to: 'user#new_seamail'
-      delete 'user/mentions', to:'user#reset_mentions'
       get 'user/mentions', to:'user#mentions'
       get 'user/auth', to: 'user#auth'
       post 'user/auth', to: 'user#auth'
@@ -76,6 +75,7 @@ Twitarr::Application.routes.draw do
 
       get 'alerts', to: 'alerts#index'
       get 'alerts/check', to: 'alerts#check'
+      post 'alerts/last_viewed', to: 'alerts#last_viewed'
 
       resources :seamail, except: [:destroy, :edit, :new], :defaults => { :format => 'json' }
       get 'seamail_threads', to: 'seamail#threads'

--- a/rest_documentation.md
+++ b/rest_documentation.md
@@ -2335,7 +2335,7 @@ Edits a post in the thread.
 Deletes a post from a thread. If the post was the only post in the thread, the thread will also be deleted.
 
 ### Requires
-* logged in as either the post author or admin
+* logged in as either the post author, or as moderator, tho, or admin.
     * Accepts: key query parameter
 
 #### Returns

--- a/rest_documentation.md
+++ b/rest_documentation.md
@@ -733,7 +733,7 @@ Both text and photo are optional, however, at least one must be specified.  If o
 
 ### DELETE /api/v2/tweet/:id
 
-Allows the user to delete a post. A user may only edit their posts, unless they are an admin.
+Allows the user to delete a post. A user may only delete their own posts, unless they are a moderator, tho, or admin user.
 
 #### Requires
 
@@ -742,7 +742,7 @@ Allows the user to delete a post. A user may only edit their posts, unless they 
 
 #### Returns
 
-No body.  200-OK
+HTTP 204 No Content if deletion was successful
 
 #### Error Responses
 * status_code_with_message
@@ -1116,7 +1116,7 @@ Get auto completion list for hashtags.  Query string length must be at least 3, 
     }
     ```
 
-### GET api/v2/hashtag/repopulate
+### GET /api/v2/hashtag/repopulate
 
 Completely rebuilds the table of hashtags. This is extremely expensive. Only admins can use this endpoint.
 
@@ -1705,9 +1705,9 @@ Gets the count of the user's unnoticed mentions. This count is increased by 1 fo
 #### Error Resposnes
 * status_code_only - HTTP 401 if user is not logged in
 
-### DELETE /api/v2/user/mentions
+### DELETE /api/v2/user/mentions # DISABLED
 
-Resets the user's unnoticed mention count to 0.
+This is no longer supported. Instead, use the alerts endpoint `POST /api/v2/alerts/last_viewed`
 
 #### Requires
 * logged in
@@ -2834,6 +2834,48 @@ Returns a count of new alerts since the user last accessed the alerts endpoint (
     }
 }
 ```
+
+### POST /api/v2/alerts/last_checked
+
+Allows a user to set their last_checked_alerts time to a specific value.
+
+#### Requires
+* logged in
+    * Accepts: key query parameter
+
+#### JSON Request Body
+
+```
+{
+	"last_checked_alerts": epoch
+}
+```
+
+#### Returns
+
+```
+{
+    "status": "ok",
+    "last_checked_alerts": epoch
+}
+```
+
+#### Error Resposnes
+* status_code_only - HTTP 401 if user is not logged in
+* HTTP 400 if last_viewed_alerts could not be parsed
+    ```
+    { 
+        "status": "error", 
+        "error": "Unable to parse last viewed alerts." 
+    }
+    ```
+* HTTP 400 if last_viewed_alerts is in the future
+    ```
+    { 
+        "status": "error", 
+        "error": "Last viewed alerts must be in the past." 
+    }
+    ```
 
 
 ## Admin Information


### PR DESCRIPTION
Don't track mentions as a count anymore. Instead, query it.
On alerts page, only return unseen mentions.
New endpoint for setting a last viewed alerts time.
Documentation updates.