### PR TITLE
Fix count_is_unread

### DIFF
--- a/app/decorators/seamail_decorator.rb
+++ b/app/decorators/seamail_decorator.rb
@@ -7,7 +7,7 @@ class SeamailDecorator < Draper::Decorator
         id: id.to_s,
         users: users.map { |x| { username: x.username, display_name: x.display_name, last_photo_updated: x.last_photo_updated.to_ms } },
         subject: subject,
-        message_count: seamail_count,
+        message_count: seamail_count(count_is_unread, current_user_id),
         timestamp: last_message.to_ms,
         is_unread: unread_for_user?(current_user_id),
         count_is_unread: count_is_unread
@@ -20,7 +20,7 @@ class SeamailDecorator < Draper::Decorator
         users: users.map { |x| { username: x.username, display_name: x.display_name, last_photo_updated: x.last_photo_updated.to_ms } },
         subject: subject,
         messages: seamail_messages.map { |x| x.decorate.to_hash(options, current_user_id, last_viewed(current_user_id)) }.compact,
-        message_count: seamail_count,
+        message_count: seamail_count(count_is_unread, current_user_id),
         timestamp: last_message.to_ms,
         is_unread: unread_for_user?(current_user_id),
         count_is_unread: count_is_unread

--- a/app/decorators/seamail_decorator.rb
+++ b/app/decorators/seamail_decorator.rb
@@ -10,7 +10,7 @@ class SeamailDecorator < Draper::Decorator
         message_count: seamail_count(count_is_unread, current_user_id),
         timestamp: last_message.to_ms,
         is_unread: unread_for_user?(current_user_id),
-        count_is_unread: count_is_unread
+        count_is_unread: count_is_unread && current_user_id > 0
     }
   end
 
@@ -23,7 +23,7 @@ class SeamailDecorator < Draper::Decorator
         message_count: seamail_count(count_is_unread, current_user_id),
         timestamp: last_message.to_ms,
         is_unread: unread_for_user?(current_user_id),
-        count_is_unread: count_is_unread
+        count_is_unread: count_is_unread && current_user_id > 0
     }
   end
 

--- a/app/models/seamail.rb
+++ b/app/models/seamail.rb
@@ -55,8 +55,13 @@ class Seamail < ApplicationRecord
     last_update
   end
 
-  def seamail_count
-    seamail_messages.count
+  def seamail_count(count_is_unread = false, user_id = 0)
+    if count_is_unread && user_id > 0
+      seamail_messages.includes(:user_seamails).references(:user_seamails)
+          .where('user_seamails.user_id = ? AND (user_seamails.last_viewed is null OR seamail_messages.created_at > user_seamails.last_viewed)', user_id).count
+    else
+      seamail_messages.count
+    end
   end
 
   def mark_as_read(user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,7 +237,7 @@ class User < ApplicationRecord
     query = query.where('seamails.last_update > ?', params[:after]) if params.key?(:after)
 
     if params.key?(:unread)
-      query = query.includes(:seamail_messages).where('user_seamails.last_viewed is null OR seamail_messages.created_at > user_seamails.last_viewed').references('seamail_messages')
+      query = query.includes(:seamail_messages).references(:seamail_messages).where('user_seamails.last_viewed is null OR seamail_messages.created_at > user_seamails.last_viewed')
       query = query.where('seamail_messages.created_at > ?', params[:after]) if params.key?(:after)
     end
 


### PR DESCRIPTION
Seamail message counting wasn't taking unread status into consideration when counting unread messages - it was just counting all messages.

Fixes #308 